### PR TITLE
NetSuite ClientRemove Void Type Hint

### DIFF
--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -63,7 +63,7 @@ class NetSuiteClient
      *
      * @return void
      */
-    public function setDataCenterUrl(array $config): void
+    public function setDataCenterUrl(array $config)
     {
         $params = new GetDataCenterUrlsRequest();
         $params->account = $config['account'];


### PR DESCRIPTION
since it's not 7.1 we cant use typehint void yet
removing it